### PR TITLE
Fix BLE write characteristic discovery

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -165,7 +165,8 @@ namespace BLESenderApp
                 foreach (var ch in charResult.Characteristics)
                 {
                     if (ch.Uuid == writeCharacteristicUuid &&
-                        ch.CharacteristicProperties.HasFlag(GattCharacteristicProperties.Write))
+                        (ch.CharacteristicProperties.HasFlag(GattCharacteristicProperties.Write)
+                        || ch.CharacteristicProperties.HasFlag(GattCharacteristicProperties.WriteWithoutResponse)))
                     {
                         writeCharacteristic = ch;
                         break;


### PR DESCRIPTION
## Summary
- allow finding characteristics that only support WriteWithoutResponse

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c2d8d35c832db2a7a415aa1588e2